### PR TITLE
ModelGenerator supporting non auto incremented primary keys

### DIFF
--- a/Dapper.SimpleCRUD.ModelGenerator/Content/Models/ModelGenerator.tt.pp
+++ b/Dapper.SimpleCRUD.ModelGenerator/Content/Models/ModelGenerator.tt.pp
@@ -68,7 +68,7 @@ foreach(Table tbl in from t in tables where !t.Ignore select t){
 	{
 <#foreach(Column col in from c in tbl.Columns where !c.Ignore select c)
 {#>
-	<# if (tbl.PK!=null && tbl.PK.IsAutoIncrement && tbl.PK.Name==col.PropertyName) { #>
+	<# if (tbl.PK!=null &&  tbl.PK.Name==col.PropertyName) { #>
 	[Key]
 	<#}#>
 	public virtual <#=col.PropertyType #><#=CheckNullable(col)#> <#=col.PropertyName #> { get; set; }


### PR DESCRIPTION
Hi Eric,

I just removed tbl.PK.IsAutoIncrement from the T4 file in order to provide support for non integer (guid in some cases) and non auto incremented primary keys. I pointed it to again Northwind, I was able to do CRUD successfully. 

Please let me know if  you find any issues with it.

Again thanks for the good project.

I will be happy to jump on any issues you or anyone else find with this project, of course if you don't mind. :)

Thanks,

Yogi
