### PR TITLE
Simplified nullable type and enum checks

### DIFF
--- a/Dapper.SimpleCRUD.Tests/Program.cs
+++ b/Dapper.SimpleCRUD.Tests/Program.cs
@@ -63,7 +63,7 @@ namespace Dapper.SimpleCRUD.Tests
                 }
                 catch {}
             }
-
+            Console.Write("Testing complete.");
             Console.ReadKey();
         }
 

--- a/Dapper.SimpleCRUD.Tests/Tests.cs
+++ b/Dapper.SimpleCRUD.Tests/Tests.cs
@@ -17,8 +17,7 @@ namespace Dapper.SimpleCRUD.Tests
         public int Id { get; set; }
         public string Name { get; set; }
         public int Age { get; set; }
-        //Use System.ComponentModel.DataAnnotations or the attribute built into SimpleCRUD
-        [Editable(true)]
+        //we modified so enums were automatically handled, we should also automatically handle nullable enums
         public DayOfWeek? ScheduledDayOff { get; set; }
     }
 
@@ -305,6 +304,17 @@ namespace Dapper.SimpleCRUD.Tests
                 //note - there's not yet support for inserts without a non-int id, so drop down to a normal execute
                 connection.Execute("INSERT INTO CITY (NAME, POPULATION) VALUES ('Fairmont', 18737)");
                 connection.Delete<City>("Fairmont").IsEqualTo(1);
+            }
+        }
+
+        public void TestNullableEnumInsert()
+        {
+            using (var connection = GetOpenConnection())
+            {
+                connection.Insert(new User { Name = "Enum-y", Age = 10, ScheduledDayOff = DayOfWeek.Thursday });
+                var user = connection.GetList<User>(new { Name = "Enum-y" }).FirstOrDefault() ?? new User();
+                user.ScheduledDayOff.IsEqualTo(DayOfWeek.Thursday);
+                connection.Delete<User>(user.Id);
             }
         }
     }

--- a/Dapper.SimpleCRUD/SimpleCRUD.cs
+++ b/Dapper.SimpleCRUD/SimpleCRUD.cs
@@ -474,6 +474,8 @@ static class TypeExtension
     //You can't insert or update complex types. Lets filter them out.
     public static bool IsSimpleType(this Type type)
     {
+        var underlyingType = Nullable.GetUnderlyingType(type);
+        type = underlyingType ?? type;
         var simpleTypes = new List<Type>
                                {
                                    typeof(byte),
@@ -493,26 +495,8 @@ static class TypeExtension
                                    typeof(Guid),
                                    typeof(DateTime),
                                    typeof(DateTimeOffset),
-                                   typeof(byte[]),
-								   typeof(DateTime?),
-								   typeof(byte?),
-                                   typeof(sbyte?),
-                                   typeof(short?),
-                                   typeof(ushort?),
-                                   typeof(int?),
-                                   typeof(uint?),
-                                   typeof(long?),
-                                   typeof(ulong?),
-                                   typeof(float?),
-                                   typeof(double?),
-                                   typeof(decimal?),
-                                   typeof(bool?),
-                                   typeof(char?),
-                                   typeof(Guid?),
-                                   typeof(DateTime?),
-                                   typeof(DateTimeOffset?),
-                                   typeof(byte?[])
+                                   typeof(byte[])
                                };
-        return simpleTypes.Contains(type)||type.IsEnum;
+        return simpleTypes.Contains(type) || type.IsEnum;
     }
 }


### PR DESCRIPTION
Switched to using Nullable.GetUnderlyingType(type) so we don't need to
explicitly check for all nullable types. This also has the side effect
of fixing checks for nullable enums without the editable attribute
(which is my main reason for this commit).
