### PR TITLE
Issue: Insert method always returns null for the primary key.

### DIFF
--- a/Dapper.SimpleCRUD/SimpleCRUD.cs
+++ b/Dapper.SimpleCRUD/SimpleCRUD.cs
@@ -153,6 +153,7 @@ namespace Dapper
             sb.Append(") values (");
             BuildInsertValues(entityToInsert, sb);
             sb.Append(")");
+            sb.Append(" select SCOPE_IDENTITY() Id");
 
             //sqlce doesn't support scope_identity so we have to dumb it down
             //sb.Append("; select cast(scope_identity() as int)");
@@ -162,9 +163,8 @@ namespace Dapper
             if (Debugger.IsAttached)
                 Trace.WriteLine(String.Format("Insert: {0}", sb));
 
-            connection.Execute(sb.ToString(), entityToInsert, transaction, commandTimeout);
-            var r = connection.Query("select @@IDENTITY id", null, transaction, true, commandTimeout);
-            return (TKey)r.First().id;             
+            var r = connection.Query(sb.ToString(), entityToInsert, transaction, true, commandTimeout);
+            return (TKey)r.First().Id;           
         }
 
 


### PR DESCRIPTION
Found that the statement "select @@IDENTITY id" was always returning null when executed through Dapper. Modified the insert statement to append SQL to retrieve the generated identity value. Changed the method used to execute the insert to .Query so that it inserts the data and returns the identity value in a single trip to the database.
