### PR TITLE
Fix returning wrong identity GUID on insert

### DIFF
--- a/Dapper.SimpleCRUD/SimpleCRUD.cs
+++ b/Dapper.SimpleCRUD/SimpleCRUD.cs
@@ -454,7 +454,7 @@ namespace Dapper
                 if (property.PropertyType != typeof(Guid) && property.GetCustomAttributes(true).Any(attr => attr.GetType().Name == "KeyAttribute")) continue;
                 if (property.GetCustomAttributes(true).Any(attr => attr.GetType().Name == "ReadOnlyAttribute" && IsReadOnly(property))) continue;
 
-                if (property.Name == "Id") continue;
+                if (property.Name == "Id" && property.PropertyType != typeof(Guid)) continue;
                 sb.AppendFormat("@{0}", property.Name);
                 if (i < props.Count() - 1)
                     sb.Append(", ");
@@ -475,7 +475,7 @@ namespace Dapper
                 var property = props.ElementAt(i);
                 if (property.PropertyType != typeof(Guid) && property.GetCustomAttributes(true).Any(attr => attr.GetType().Name == "KeyAttribute")) continue;
                 if (property.GetCustomAttributes(true).Any(attr => attr.GetType().Name == "ReadOnlyAttribute" && IsReadOnly(property))) continue;
-                if (property.Name == "Id") continue;
+                if (property.Name == "Id" && property.PropertyType != typeof(Guid)) continue;
                 sb.Append(GetColumnName(property));
                 if (i < props.Count() - 1)
                     sb.Append(", ");


### PR DESCRIPTION
A GUID is being created and returned on insert but never actually
applied to the insert query. 

This can be seen on a table where the key
is a GUID and defaults to (newid()) and no GUID is provided on the
insert. Dapper will generate a GUID but it is not applied so the GUID is
generated by newid() but the Dapper GUID is returned instead which is
incorrect.