### PR TITLE
Lower case "id" parameter in Get function bug fixed

### DIFF
--- a/Dapper.SimpleCRUD/SimpleCRUD.cs
+++ b/Dapper.SimpleCRUD/SimpleCRUD.cs
@@ -104,7 +104,7 @@ namespace Dapper
             sb.Append(" where " + GetColumnName(onlyKey) + " = @Id");
 
             var dynParms = new DynamicParameters();
-            dynParms.Add("@id", id);
+            dynParms.Add("@Id", id);
 
             if (Debugger.IsAttached)
                 Trace.WriteLine(String.Format("Get<{0}>: {1} with Id: {2}", currenttype, sb, id));


### PR DESCRIPTION
In Get function, id parameter was  added as "@Id" but value set as "@id". It's been fixed now.