### PR TITLE
Fix(IsPrimaryKeyColumn)

### DIFF
--- a/Dapper.SimpleCRUD.ModelGenerator/Content/Models/ModelGenerator.tt.pp
+++ b/Dapper.SimpleCRUD.ModelGenerator/Content/Models/ModelGenerator.tt.pp
@@ -126,7 +126,9 @@ public class Table
 
 	public bool IsPrimaryKeyColumn(string columnName)
 	{
-		return Columns.Single(x=>string.Compare(x.Name, columnName, true)==0).IsPK;
+		//return Columns.Single(x=>string.Compare(x.Name, columnName, true)==0).IsPK;
+		var found = Columns.FirstOrDefault(x=> string.Compare(x.Name, columnName, true)==0);		
+		return found == null ? false : found.IsPK;
 	}
 
 	public Column GetColumn(string columnName)


### PR DESCRIPTION
When sanitizing property name by `c.PropertyName = rxClean.Replace(c.PropertyName, "_$1");`
using single to find the column will cause `"InvalidOperationException: Sequence contains no matching element"`	

Example: 
Table with column name `	[Query] [varchar](max) NULL`
will generate property name `_Query` which will cause `IsPrimaryKeyColumn()` to throw an Exception.