### PR TITLE
Added Query Builders Cache.

### DIFF
--- a/Dapper.SimpleCRUD/SimpleCRUD.cs
+++ b/Dapper.SimpleCRUD/SimpleCRUD.cs
@@ -29,9 +29,33 @@ namespace Dapper
         private static readonly ConcurrentDictionary<Type, string> TableNames = new ConcurrentDictionary<Type, string>();
         private static readonly ConcurrentDictionary<string, string> ColumnNames = new ConcurrentDictionary<string, string>();
 
+        private static readonly ConcurrentDictionary<string, string> StringBuilderCacheDict = new ConcurrentDictionary<string, string>();
+        private static bool StringBuilderCacheEnabled = true;
+
         private static ITableNameResolver _tableNameResolver = new TableNameResolver();
         private static IColumnNameResolver _columnNameResolver = new ColumnNameResolver();
 
+        /// <summary>
+        /// Append a Cached version of a strinbBuilderAction result based on a cacheKey
+        /// </summary>
+        /// <param name="sb"></param>
+        /// <param name="cacheKey"></param>
+        /// <param name="stringBuilderAction"></param>
+        private static void StringBuilderCache(StringBuilder sb, string cacheKey, Action<StringBuilder> stringBuilderAction)
+        {
+            if (StringBuilderCacheEnabled && StringBuilderCacheDict.TryGetValue(cacheKey, out string value))
+            {
+                sb.Append(value);
+                return;
+            }
+
+            StringBuilder newSb = new StringBuilder();
+            stringBuilderAction(newSb);
+            value = newSb.ToString();
+            StringBuilderCacheDict.AddOrUpdate(cacheKey, value, (t, v) => value);
+            sb.Append(value);
+        }
+        
         /// <summary>
         /// Returns the current dialect name
         /// </summary>
@@ -405,25 +429,27 @@ namespace Dapper
         /// <returns>The number of affected records</returns>
         public static int Update<TEntity>(this IDbConnection connection, TEntity entityToUpdate, IDbTransaction transaction = null, int? commandTimeout = null)
         {
-            var idProps = GetIdProperties(entityToUpdate).ToList();
+            var masterSb = new StringBuilder();
+            StringBuilderCache(masterSb, $"{typeof(TEntity).FullName}_Update", sb =>
+            {
+                var idProps = GetIdProperties(entityToUpdate).ToList();
 
-            if (!idProps.Any())
-                throw new ArgumentException("Entity must have at least one [Key] or Id property");
+                if (!idProps.Any())
+                    throw new ArgumentException("Entity must have at least one [Key] or Id property");
 
-            var name = GetTableName(entityToUpdate);
+                var name = GetTableName(entityToUpdate);
 
-            var sb = new StringBuilder();
-            sb.AppendFormat("update {0}", name);
+                sb.AppendFormat("update {0}", name);
 
-            sb.AppendFormat(" set ");
-            BuildUpdateSet(entityToUpdate, sb);
-            sb.Append(" where ");
-            BuildWhere<TEntity>(sb, idProps, entityToUpdate);
+                sb.AppendFormat(" set ");
+                BuildUpdateSet(entityToUpdate, sb);
+                sb.Append(" where ");
+                BuildWhere<TEntity>(sb, idProps, entityToUpdate);
 
-            if (Debugger.IsAttached)
-                Trace.WriteLine(String.Format("Update: {0}", sb));
-
-            return connection.Execute(sb.ToString(), entityToUpdate, transaction, commandTimeout);
+                if (Debugger.IsAttached)
+                    Trace.WriteLine(String.Format("Update: {0}", sb));
+            });
+            return connection.Execute(masterSb.ToString(), entityToUpdate, transaction, commandTimeout);
         }
 
         /// <summary>
@@ -441,24 +467,26 @@ namespace Dapper
         /// <returns>The number of records affected</returns>
         public static int Delete<T>(this IDbConnection connection, T entityToDelete, IDbTransaction transaction = null, int? commandTimeout = null)
         {
-            var idProps = GetIdProperties(entityToDelete).ToList();
+            var masterSb = new StringBuilder();
+            StringBuilderCache(masterSb, $"{typeof(T).FullName}_Delete", sb =>
+            {
 
+                var idProps = GetIdProperties(entityToDelete).ToList();
 
-            if (!idProps.Any())
-                throw new ArgumentException("Entity must have at least one [Key] or Id property");
+                if (!idProps.Any())
+                    throw new ArgumentException("Entity must have at least one [Key] or Id property");
 
-            var name = GetTableName(entityToDelete);
+                var name = GetTableName(entityToDelete);
 
-            var sb = new StringBuilder();
-            sb.AppendFormat("delete from {0}", name);
+                sb.AppendFormat("delete from {0}", name);
 
-            sb.Append(" where ");
-            BuildWhere<T>(sb, idProps, entityToDelete);
+                sb.Append(" where ");
+                BuildWhere<T>(sb, idProps, entityToDelete);
 
-            if (Debugger.IsAttached)
-                Trace.WriteLine(String.Format("Delete: {0}", sb));
-
-            return connection.Execute(sb.ToString(), entityToDelete, transaction, commandTimeout);
+                if (Debugger.IsAttached)
+                    Trace.WriteLine(String.Format("Delete: {0}", sb));
+            });
+            return connection.Execute(masterSb.ToString(), entityToDelete, transaction, commandTimeout);
         }
 
         /// <summary>
@@ -528,23 +556,24 @@ namespace Dapper
         /// <returns>The number of records affected</returns>
         public static int DeleteList<T>(this IDbConnection connection, object whereConditions, IDbTransaction transaction = null, int? commandTimeout = null)
         {
-
-            var currenttype = typeof(T);
-            var name = GetTableName(currenttype);
-
-            var sb = new StringBuilder();
-            var whereprops = GetAllProperties(whereConditions).ToArray();
-            sb.AppendFormat("Delete from {0}", name);
-            if (whereprops.Any())
+            var masterSb = new StringBuilder();
+            StringBuilderCache(masterSb, $"{typeof(T).FullName}_DeleteWhere{whereConditions?.GetType()?.FullName}", sb =>
             {
-                sb.Append(" where ");
-                BuildWhere<T>(sb, whereprops);
-            }
+                var currenttype = typeof(T);
+                var name = GetTableName(currenttype);
 
-            if (Debugger.IsAttached)
-                Trace.WriteLine(String.Format("DeleteList<{0}> {1}", currenttype, sb));
+                var whereprops = GetAllProperties(whereConditions).ToArray();
+                sb.AppendFormat("Delete from {0}", name);
+                if (whereprops.Any())
+                {
+                    sb.Append(" where ");
+                    BuildWhere<T>(sb, whereprops);
+                }
 
-            return connection.Execute(sb.ToString(), whereConditions, transaction, commandTimeout);
+                if (Debugger.IsAttached)
+                    Trace.WriteLine(String.Format("DeleteList<{0}> {1}", currenttype, sb));
+            });
+            return connection.Execute(masterSb.ToString(), whereConditions, transaction, commandTimeout);
         }
 
         /// <summary>
@@ -565,22 +594,24 @@ namespace Dapper
         /// <returns>The number of records affected</returns>
         public static int DeleteList<T>(this IDbConnection connection, string conditions, object parameters = null, IDbTransaction transaction = null, int? commandTimeout = null)
         {
-            if (string.IsNullOrEmpty(conditions))
-                throw new ArgumentException("DeleteList<T> requires a where clause");
-            if (!conditions.ToLower().Contains("where"))
-                throw new ArgumentException("DeleteList<T> requires a where clause and must contain the WHERE keyword");
+            var masterSb = new StringBuilder();
+            StringBuilderCache(masterSb, $"{typeof(T).FullName}_DeleteWhere{conditions}", sb =>
+            {
+                if (string.IsNullOrEmpty(conditions))
+                    throw new ArgumentException("DeleteList<T> requires a where clause");
+                if (!conditions.ToLower().Contains("where"))
+                    throw new ArgumentException("DeleteList<T> requires a where clause and must contain the WHERE keyword");
 
-            var currenttype = typeof(T);
-            var name = GetTableName(currenttype);
+                var currenttype = typeof(T);
+                var name = GetTableName(currenttype);
 
-            var sb = new StringBuilder();
-            sb.AppendFormat("Delete from {0}", name);
-            sb.Append(" " + conditions);
+                sb.AppendFormat("Delete from {0}", name);
+                sb.Append(" " + conditions);
 
-            if (Debugger.IsAttached)
-                Trace.WriteLine(String.Format("DeleteList<{0}> {1}", currenttype, sb));
-
-            return connection.Execute(sb.ToString(), parameters, transaction, commandTimeout);
+                if (Debugger.IsAttached)
+                    Trace.WriteLine(String.Format("DeleteList<{0}> {1}", currenttype, sb));
+            });
+            return connection.Execute(masterSb.ToString(), parameters, transaction, commandTimeout);
         }
 
         /// <summary>
@@ -648,39 +679,45 @@ namespace Dapper
         }
 
         //build update statement based on list on an entity
-        private static void BuildUpdateSet<T>(T entityToUpdate, StringBuilder sb)
+        private static void BuildUpdateSet<T>(T entityToUpdate, StringBuilder masterSb)
         {
-            var nonIdProps = GetUpdateableProperties(entityToUpdate).ToArray();
-
-            for (var i = 0; i < nonIdProps.Length; i++)
+            StringBuilderCache(masterSb, $"{typeof(T).FullName}_BuildUpdateSet", sb =>
             {
-                var property = nonIdProps[i];
+                var nonIdProps = GetUpdateableProperties(entityToUpdate).ToArray();
 
-                sb.AppendFormat("{0} = @{1}", GetColumnName(property), property.Name);
-                if (i < nonIdProps.Length - 1)
-                    sb.AppendFormat(", ");
-            }
+                for (var i = 0; i < nonIdProps.Length; i++)
+                {
+                    var property = nonIdProps[i];
+
+                    sb.AppendFormat("{0} = @{1}", GetColumnName(property), property.Name);
+                    if (i < nonIdProps.Length - 1)
+                        sb.AppendFormat(", ");
+                }
+            });
         }
 
         //build select clause based on list of properties skipping ones with the IgnoreSelect and NotMapped attribute
-        private static void BuildSelect(StringBuilder sb, IEnumerable<PropertyInfo> props)
+        private static void BuildSelect(StringBuilder masterSb, IEnumerable<PropertyInfo> props)
         {
-            var propertyInfos = props as IList<PropertyInfo> ?? props.ToList();
-            var addedAny = false;
-            for (var i = 0; i < propertyInfos.Count(); i++)
+            StringBuilderCache(masterSb, $"{props.CacheKey()}_BuildSelect", sb =>
             {
-                var property = propertyInfos.ElementAt(i);
+                var propertyInfos = props as IList<PropertyInfo> ?? props.ToList();
+                var addedAny = false;
+                for (var i = 0; i < propertyInfos.Count(); i++)
+                {
+                    var property = propertyInfos.ElementAt(i);
 
-                if (property.GetCustomAttributes(true).Any(attr => attr.GetType().Name == typeof(IgnoreSelectAttribute).Name || attr.GetType().Name == typeof(NotMappedAttribute).Name)) continue;
+                    if (property.GetCustomAttributes(true).Any(attr => attr.GetType().Name == typeof(IgnoreSelectAttribute).Name || attr.GetType().Name == typeof(NotMappedAttribute).Name)) continue;
 
-                if (addedAny)
-                    sb.Append(",");
-                sb.Append(GetColumnName(property));
-                //if there is a custom column name add an "as customcolumnname" to the item so it maps properly
-                if (property.GetCustomAttributes(true).SingleOrDefault(attr => attr.GetType().Name == typeof(ColumnAttribute).Name) != null)
-                    sb.Append(" as " + Encapsulate(property.Name));
-                addedAny = true;
-            }
+                    if (addedAny)
+                        sb.Append(",");
+                    sb.Append(GetColumnName(property));
+                    //if there is a custom column name add an "as customcolumnname" to the item so it maps properly
+                    if (property.GetCustomAttributes(true).SingleOrDefault(attr => attr.GetType().Name == typeof(ColumnAttribute).Name) != null)
+                        sb.Append(" as " + Encapsulate(property.Name));
+                    addedAny = true;
+                }
+            });
         }
 
         private static void BuildWhere<TEntity>(StringBuilder sb, IEnumerable<PropertyInfo> idProps, object whereConditions = null)
@@ -723,31 +760,34 @@ namespace Dapper
         //Not marked with the [Key] attribute (without required attribute)
         //Not marked with [IgnoreInsert]
         //Not marked with [NotMapped]
-        private static void BuildInsertValues<T>(StringBuilder sb)
+        private static void BuildInsertValues<T>(StringBuilder masterSb)
         {
-            var props = GetScaffoldableProperties<T>().ToArray();
-            for (var i = 0; i < props.Count(); i++)
+            StringBuilderCache(masterSb, $"{typeof(T).FullName}_BuildInsertValues", sb =>
             {
-                var property = props.ElementAt(i);
-                if (property.PropertyType != typeof(Guid) && property.PropertyType != typeof(string)
-                      && property.GetCustomAttributes(true).Any(attr => attr.GetType().Name == typeof(KeyAttribute).Name)
-                      && property.GetCustomAttributes(true).All(attr => attr.GetType().Name != typeof(RequiredAttribute).Name))
-                    continue;
-                if (property.GetCustomAttributes(true).Any(attr => 
-                    attr.GetType().Name == typeof(IgnoreInsertAttribute).Name ||
-                    attr.GetType().Name == typeof(NotMappedAttribute).Name ||
-                    attr.GetType().Name == typeof(ReadOnlyAttribute).Name && IsReadOnly(property))
-                ) continue;
 
-                if (property.Name.Equals("Id", StringComparison.OrdinalIgnoreCase) && property.GetCustomAttributes(true).All(attr => attr.GetType().Name != typeof(RequiredAttribute).Name) && property.PropertyType != typeof(Guid)) continue;
+                var props = GetScaffoldableProperties<T>().ToArray();
+                for (var i = 0; i < props.Count(); i++)
+                {
+                    var property = props.ElementAt(i);
+                    if (property.PropertyType != typeof(Guid) && property.PropertyType != typeof(string)
+                          && property.GetCustomAttributes(true).Any(attr => attr.GetType().Name == typeof(KeyAttribute).Name)
+                          && property.GetCustomAttributes(true).All(attr => attr.GetType().Name != typeof(RequiredAttribute).Name))
+                        continue;
+                    if (property.GetCustomAttributes(true).Any(attr =>
+                        attr.GetType().Name == typeof(IgnoreInsertAttribute).Name ||
+                        attr.GetType().Name == typeof(NotMappedAttribute).Name ||
+                        attr.GetType().Name == typeof(ReadOnlyAttribute).Name && IsReadOnly(property))
+                    ) continue;
 
-                sb.AppendFormat("@{0}", property.Name);
-                if (i < props.Count() - 1)
-                    sb.Append(", ");
-            }
-            if (sb.ToString().EndsWith(", "))
-                sb.Remove(sb.Length - 2, 2);
+                    if (property.Name.Equals("Id", StringComparison.OrdinalIgnoreCase) && property.GetCustomAttributes(true).All(attr => attr.GetType().Name != typeof(RequiredAttribute).Name) && property.PropertyType != typeof(Guid)) continue;
 
+                    sb.AppendFormat("@{0}", property.Name);
+                    if (i < props.Count() - 1)
+                        sb.Append(", ");
+                }
+                if (sb.ToString().EndsWith(", "))
+                    sb.Remove(sb.Length - 2, 2);
+            });
         }
 
         //build insert parameters which include all properties in the class that are not:
@@ -756,30 +796,33 @@ namespace Dapper
         //marked with [IgnoreInsert]
         //named Id
         //marked with [NotMapped]
-        private static void BuildInsertParameters<T>(StringBuilder sb)
+        private static void BuildInsertParameters<T>(StringBuilder masterSb)
         {
-            var props = GetScaffoldableProperties<T>().ToArray();
-
-            for (var i = 0; i < props.Count(); i++)
+            StringBuilderCache(masterSb, $"{typeof(T).FullName}_BuildInsertParameters", sb =>
             {
-                var property = props.ElementAt(i);
-                if (property.PropertyType != typeof(Guid) && property.PropertyType != typeof(string)
-                      && property.GetCustomAttributes(true).Any(attr => attr.GetType().Name == typeof(KeyAttribute).Name)
-                      && property.GetCustomAttributes(true).All(attr => attr.GetType().Name != typeof(RequiredAttribute).Name))
-                    continue;
-                if (property.GetCustomAttributes(true).Any(attr => 
-                    attr.GetType().Name == typeof(IgnoreInsertAttribute).Name ||
-                    attr.GetType().Name == typeof(NotMappedAttribute).Name ||
-                    attr.GetType().Name == typeof(ReadOnlyAttribute).Name && IsReadOnly(property))) continue;
-                
-                if (property.Name.Equals("Id", StringComparison.OrdinalIgnoreCase) && property.GetCustomAttributes(true).All(attr => attr.GetType().Name != typeof(RequiredAttribute).Name) && property.PropertyType != typeof(Guid)) continue;
+                var props = GetScaffoldableProperties<T>().ToArray();
 
-                sb.Append(GetColumnName(property));
-                if (i < props.Count() - 1)
-                    sb.Append(", ");
-            }
-            if (sb.ToString().EndsWith(", "))
-                sb.Remove(sb.Length - 2, 2);
+                for (var i = 0; i < props.Count(); i++)
+                {
+                    var property = props.ElementAt(i);
+                    if (property.PropertyType != typeof(Guid) && property.PropertyType != typeof(string)
+                          && property.GetCustomAttributes(true).Any(attr => attr.GetType().Name == typeof(KeyAttribute).Name)
+                          && property.GetCustomAttributes(true).All(attr => attr.GetType().Name != typeof(RequiredAttribute).Name))
+                        continue;
+                    if (property.GetCustomAttributes(true).Any(attr =>
+                        attr.GetType().Name == typeof(IgnoreInsertAttribute).Name ||
+                        attr.GetType().Name == typeof(NotMappedAttribute).Name ||
+                        attr.GetType().Name == typeof(ReadOnlyAttribute).Name && IsReadOnly(property))) continue;
+
+                    if (property.Name.Equals("Id", StringComparison.OrdinalIgnoreCase) && property.GetCustomAttributes(true).All(attr => attr.GetType().Name != typeof(RequiredAttribute).Name) && property.PropertyType != typeof(Guid)) continue;
+
+                    sb.Append(GetColumnName(property));
+                    if (i < props.Count() - 1)
+                        sb.Append(", ");
+                }
+                if (sb.ToString().EndsWith(", "))
+                    sb.Remove(sb.Length - 2, 2);
+            });
         }
 
         //Get all properties in an entity
@@ -1178,5 +1221,10 @@ internal static class TypeExtension
                                    typeof(byte[])
                                };
         return simpleTypes.Contains(type) || type.IsEnum;
+    }
+
+    public static string CacheKey(this IEnumerable<PropertyInfo> props)
+    {
+        return string.Join(",",props.Select(p=> p.DeclaringType.FullName + "." + p.Name).ToArray());
     }
 }

--- a/Dapper.SimpleCRUDTests/Tests.cs
+++ b/Dapper.SimpleCRUDTests/Tests.cs
@@ -214,6 +214,36 @@ namespace Dapper.SimpleCRUDTests
             }
         }
 
+        public void TestMassInsert() 
+        {
+            //With cached strinb builder, this tests runs 2.5X faster (From 400ms to 180ms)
+            using (var connection = GetOpenConnection())
+            using (var transaction = connection.BeginTransaction())
+            {
+                for (int i = 0; i < 1000; i++)
+                {
+                    var id = connection.Insert(new User { Name = $"Name #{i}", Age = i }, transaction);
+                }
+            }
+        }
+
+        public void TestMassUpdate() //356
+        {
+            //With cached strinb builder, this tests runs 2.5X faster (From 375ms to 140ms)
+            using (var connection = GetOpenConnection())
+            using (var transaction = connection.BeginTransaction())
+            {
+                var id = connection.Insert(new User { Name = "New User", Age = 0 }, transaction);
+                var user = connection.Get<User>(id, transaction);
+
+                for (int i = 1; i <= 1000; i++)
+                {
+                    user.Age = i;
+                    connection.Update(user, transaction);
+                }
+            }
+        }
+
         public void TestInsertUsingBigIntPrimaryKey()
         {
             using (var connection = GetOpenConnection())


### PR DESCRIPTION
New function StringBuilderCache that can append a cached version of a functor argument.

Improve performance on mass Inserts/Updates by a factor of 2.5.
Added 2 Tests for Mass Update & Mass Insert (1000 records). This is even more true for 10,000s of records & more.
All previous tests passes

Can turn off this feature by setting bool StringBuilderCacheEnabled to false. That's how i've been able to test performance improvement.