### PR TITLE
Optional Soft Delete

### DIFF
--- a/Dapper.SimpleCRUD/Dapper.SimpleCRUD.csproj
+++ b/Dapper.SimpleCRUD/Dapper.SimpleCRUD.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="1.50.5" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">

--- a/Dapper.SimpleCRUD/SimpleCRUDAsync.cs
+++ b/Dapper.SimpleCRUD/SimpleCRUDAsync.cs
@@ -29,39 +29,8 @@ namespace Dapper
         /// <returns>Returns a single entity by a single id from table T.</returns>
         public static async Task<T> GetAsync<T>(this IDbConnection connection, object id, IDbTransaction transaction = null, int? commandTimeout = null)
         {
-            var currenttype = typeof(T);
-            var idProps = GetIdProperties(currenttype).ToList();
-
-            if (!idProps.Any())
-                throw new ArgumentException("Get<T> only supports an entity with a [Key] or Id property");
-
-            var name = GetTableName(currenttype);
-            var sb = new StringBuilder();
-            sb.Append("Select ");
-            //create a new empty instance of the type to get the base properties
-            BuildSelect(sb, GetScaffoldableProperties<T>().ToArray());
-            sb.AppendFormat(" from {0} where ", name);
-
-            for (var i = 0; i < idProps.Count; i++)
-            {
-                if (i > 0)
-                    sb.Append(" and ");
-                sb.AppendFormat("{0} = @{1}", GetColumnName(idProps[i]), idProps[i].Name);
-            }
-
-            var dynParms = new DynamicParameters();
-            if (idProps.Count == 1)
-                dynParms.Add("@" + idProps.First().Name, id);
-            else
-            {
-                foreach (var prop in idProps)
-                    dynParms.Add("@" + prop.Name, id.GetType().GetProperty(prop.Name).GetValue(id, null));
-            }
-
-            if (Debugger.IsAttached)
-                Trace.WriteLine(String.Format("Get<{0}>: {1} with Id: {2}", currenttype, sb, id));
-
-            var query = await connection.QueryAsync<T>(sb.ToString(), dynParms, transaction, commandTimeout);
+            var builder = BuildGetQuery<T>(id);
+            var query = await connection.QueryAsync<T>(builder.query, builder.parameters, transaction, commandTimeout);
             return query.FirstOrDefault();
         }
 
@@ -80,31 +49,8 @@ namespace Dapper
         /// <returns>Gets a list of entities with optional exact match where conditions</returns>
         public static Task<IEnumerable<T>> GetListAsync<T>(this IDbConnection connection, object whereConditions, IDbTransaction transaction = null, int? commandTimeout = null)
         {
-            var currenttype = typeof(T);
-            var idProps = GetIdProperties(currenttype).ToList();
-
-            if (!idProps.Any())
-                throw new ArgumentException("Entity must have at least one [Key] property");
-
-            var name = GetTableName(currenttype);
-
-            var sb = new StringBuilder();
-            var whereprops = GetAllProperties(whereConditions).ToArray();
-            sb.Append("Select ");
-            //create a new empty instance of the type to get the base properties
-            BuildSelect(sb, GetScaffoldableProperties<T>().ToArray());
-            sb.AppendFormat(" from {0}", name);
-
-            if (whereprops.Any())
-            {
-                sb.Append(" where ");
-                BuildWhere<T>(sb, whereprops, whereConditions);
-            }
-
-            if (Debugger.IsAttached)
-                Trace.WriteLine(String.Format("GetList<{0}>: {1}", currenttype, sb));
-
-            return connection.QueryAsync<T>(sb.ToString(), whereConditions, transaction, commandTimeout);
+            var builder = BuildGetListQuery<T>(whereConditions);
+            return connection.QueryAsync<T>(builder, whereConditions, transaction, commandTimeout);
         }
 
         /// <summary>
@@ -124,25 +70,8 @@ namespace Dapper
         /// <returns>Gets a list of entities with optional SQL where conditions</returns>
         public static Task<IEnumerable<T>> GetListAsync<T>(this IDbConnection connection, string conditions, object parameters = null, IDbTransaction transaction = null, int? commandTimeout = null)
         {
-            var currenttype = typeof(T);
-            var idProps = GetIdProperties(currenttype).ToList();
-            if (!idProps.Any())
-                throw new ArgumentException("Entity must have at least one [Key] property");
-
-            var name = GetTableName(currenttype);
-
-            var sb = new StringBuilder();
-            sb.Append("Select ");
-            //create a new empty instance of the type to get the base properties
-            BuildSelect(sb, GetScaffoldableProperties<T>().ToArray());
-            sb.AppendFormat(" from {0}", name);
-
-            sb.Append(" " + conditions);
-
-            if (Debugger.IsAttached)
-                Trace.WriteLine(String.Format("GetList<{0}>: {1}", currenttype, sb));
-
-            return connection.QueryAsync<T>(sb.ToString(), parameters, transaction, commandTimeout);
+            var query = BuildGetListQuery<T>(conditions);
+            return connection.QueryAsync<T>(query, parameters, transaction, commandTimeout);
         }
 
         /// <summary>
@@ -178,35 +107,7 @@ namespace Dapper
         /// <returns>Gets a list of entities with optional exact match where conditions</returns>
         public static Task<IEnumerable<T>> GetListPagedAsync<T>(this IDbConnection connection, int pageNumber, int rowsPerPage, string conditions, string orderby, object parameters = null, IDbTransaction transaction = null, int? commandTimeout = null)
         {
-            if (string.IsNullOrEmpty(_getPagedListSql))
-                throw new Exception("GetListPage is not supported with the current SQL Dialect");
-
-            var currenttype = typeof(T);
-            var idProps = GetIdProperties(currenttype).ToList();
-            if (!idProps.Any())
-                throw new ArgumentException("Entity must have at least one [Key] property");
-
-            var name = GetTableName(currenttype);
-            var sb = new StringBuilder();
-            var query = _getPagedListSql;
-            if (string.IsNullOrEmpty(orderby))
-            {
-                orderby = GetColumnName(idProps.First());
-            }
-
-            //create a new empty instance of the type to get the base properties
-            BuildSelect(sb, GetScaffoldableProperties<T>().ToArray());
-            query = query.Replace("{SelectColumns}", sb.ToString());
-            query = query.Replace("{TableName}", name);
-            query = query.Replace("{PageNumber}", pageNumber.ToString());
-            query = query.Replace("{RowsPerPage}", rowsPerPage.ToString());
-            query = query.Replace("{OrderBy}", orderby);
-            query = query.Replace("{WhereClause}", conditions);
-            query = query.Replace("{Offset}", ((pageNumber - 1) * rowsPerPage).ToString());
-
-            if (Debugger.IsAttached)
-                Trace.WriteLine(String.Format("GetListPaged<{0}>: {1}", currenttype, query));
-
+            var query = BuildGetListPagedQuery<T>(pageNumber, rowsPerPage, conditions, orderby);
             return connection.QueryAsync<T>(query, parameters, transaction, commandTimeout);
         }
 
@@ -245,64 +146,9 @@ namespace Dapper
         /// <returns>The ID (primary key) of the newly inserted record if it is identity using the defined type, otherwise null</returns>
         public static async Task<TKey> InsertAsync<TKey, TEntity>(this IDbConnection connection, TEntity entityToInsert, IDbTransaction transaction = null, int? commandTimeout = null)
         {
-            var idProps = GetIdProperties(entityToInsert).ToList();
-
-            if (!idProps.Any())
-                throw new ArgumentException("Insert<T> only supports an entity with a [Key] or Id property");
-
-            var keyHasPredefinedValue = false;
-            var baseType = typeof(TKey);
-            var underlyingType = Nullable.GetUnderlyingType(baseType);
-            var keytype = underlyingType ?? baseType;
-            if (keytype != typeof(int) && keytype != typeof(uint) && keytype != typeof(long) && keytype != typeof(ulong) && keytype != typeof(short) && keytype != typeof(ushort) && keytype != typeof(Guid) && keytype != typeof(string))
-            {
-                throw new Exception("Invalid return type");
-            }
-
-            var name = GetTableName(entityToInsert);
-            var sb = new StringBuilder();
-            sb.AppendFormat("insert into {0}", name);
-            sb.Append(" (");
-            BuildInsertParameters<TEntity>(sb);
-            sb.Append(") ");
-            sb.Append("values");
-            sb.Append(" (");
-            BuildInsertValues<TEntity>(sb);
-            sb.Append(")");
-
-            if (keytype == typeof(Guid))
-            {
-                var guidvalue = (Guid)idProps.First().GetValue(entityToInsert, null);
-                if (guidvalue == Guid.Empty)
-                {
-                    var newguid = SequentialGuid();
-                    idProps.First().SetValue(entityToInsert, newguid, null);
-                }
-                else
-                {
-                    keyHasPredefinedValue = true;
-                }
-            }
-
-            if ((keytype == typeof(int) || keytype == typeof(long)) && Convert.ToInt64(idProps.First().GetValue(entityToInsert, null)) == 0)
-            {
-                sb.Append(";" + _getIdentitySql);
-            }
-            else
-            {
-                keyHasPredefinedValue = true;
-            }
-
-            if (Debugger.IsAttached)
-                Trace.WriteLine(String.Format("Insert: {0}", sb));
-
-            if (keytype == typeof(Guid) || keyHasPredefinedValue)
-            {
-                await connection.ExecuteAsync(sb.ToString(), entityToInsert, transaction, commandTimeout);
-                return (TKey)idProps.First().GetValue(entityToInsert, null);
-            }
-            var r = await connection.QueryAsync(sb.ToString(), entityToInsert, transaction, commandTimeout);
-            return (TKey)r.First().id;
+            var builder = BuildInsertQuery<TKey, TEntity>(entityToInsert);
+            var r = await connection.QueryAsync(builder.sb, entityToInsert, transaction, commandTimeout);
+            return ReturnInsertKey<TKey, TEntity>(builder, entityToInsert, r);
         }
         
         /// <summary>
@@ -321,26 +167,9 @@ namespace Dapper
         /// <returns>The number of affected records</returns>
         public static Task<int> UpdateAsync<TEntity>(this IDbConnection connection, TEntity entityToUpdate, IDbTransaction transaction = null, int? commandTimeout = null, System.Threading.CancellationToken? token = null)
         {
-            var idProps = GetIdProperties(entityToUpdate).ToList();
-
-            if (!idProps.Any())
-                throw new ArgumentException("Entity must have at least one [Key] or Id property");
-
-            var name = GetTableName(entityToUpdate);
-
-            var sb = new StringBuilder();
-            sb.AppendFormat("update {0}", name);
-
-            sb.AppendFormat(" set ");
-            BuildUpdateSet(entityToUpdate, sb);
-            sb.Append(" where ");
-            BuildWhere<TEntity>(sb, idProps, entityToUpdate);
-
-            if (Debugger.IsAttached)
-                Trace.WriteLine(String.Format("Update: {0}", sb));
-
+            var sb = BuildUpdateQuery<TEntity>(entityToUpdate);
             System.Threading.CancellationToken cancelToken = token ?? default(System.Threading.CancellationToken);
-            return connection.ExecuteAsync(new CommandDefinition(sb.ToString(), entityToUpdate, transaction, commandTimeout, cancellationToken: cancelToken));
+            return connection.ExecuteAsync(new CommandDefinition(sb, entityToUpdate, transaction, commandTimeout, cancellationToken: cancelToken));
         }
 
         /// <summary>
@@ -358,23 +187,8 @@ namespace Dapper
         /// <returns>The number of records affected</returns>
         public static Task<int> DeleteAsync<T>(this IDbConnection connection, T entityToDelete, IDbTransaction transaction = null, int? commandTimeout = null)
         {
-            var idProps = GetIdProperties(entityToDelete).ToList();
-
-            if (!idProps.Any())
-                throw new ArgumentException("Entity must have at least one [Key] or Id property");
-
-            var name = GetTableName(entityToDelete);
-
-            var sb = new StringBuilder();
-            sb.AppendFormat("delete from {0}", name);
-
-            sb.Append(" where ");
-            BuildWhere<T>(sb, idProps, entityToDelete);
-
-            if (Debugger.IsAttached)
-                Trace.WriteLine(String.Format("Delete: {0}", sb));
-
-            return connection.ExecuteAsync(sb.ToString(), entityToDelete, transaction, commandTimeout);
+            var sb = BuildDeleteQuery<T>(entityToDelete);
+            return connection.ExecuteAsync(sb, entityToDelete, transaction, commandTimeout);
         }
 
         /// <summary>
@@ -393,37 +207,8 @@ namespace Dapper
         /// <returns>The number of records affected</returns>
         public static Task<int> DeleteAsync<T>(this IDbConnection connection, object id, IDbTransaction transaction = null, int? commandTimeout = null)
         {
-            var currenttype = typeof(T);
-            var idProps = GetIdProperties(currenttype).ToList();
-            
-            if (!idProps.Any())
-                throw new ArgumentException("Delete<T> only supports an entity with a [Key] or Id property");
-
-            var name = GetTableName(currenttype);
-
-            var sb = new StringBuilder();
-            sb.AppendFormat("Delete from {0} where ", name);
-
-            for (var i = 0; i < idProps.Count; i++)
-            {
-                if (i > 0)
-                    sb.Append(" and ");
-                sb.AppendFormat("{0} = @{1}", GetColumnName(idProps[i]), idProps[i].Name);
-            }
-
-            var dynParms = new DynamicParameters();
-            if (idProps.Count == 1)
-                dynParms.Add("@" + idProps.First().Name, id);
-            else
-            {
-                foreach (var prop in idProps)
-                    dynParms.Add("@" + prop.Name, prop.GetValue(id));
-            }
-
-            if (Debugger.IsAttached)
-                Trace.WriteLine(String.Format("Delete<{0}> {1}", currenttype, sb));
-
-            return connection.ExecuteAsync(sb.ToString(), dynParms, transaction, commandTimeout);
+            var (sb, dynParms) = BuildDeleteQuery<T>(id);
+            return connection.ExecuteAsync(sb, dynParms, transaction, commandTimeout);
         }
 
 
@@ -444,23 +229,8 @@ namespace Dapper
         /// <returns>The number of records affected</returns>
         public static Task<int> DeleteListAsync<T>(this IDbConnection connection, object whereConditions, IDbTransaction transaction = null, int? commandTimeout = null)
         {
-
-            var currenttype = typeof(T);
-            var name = GetTableName(currenttype);
-
-            var sb = new StringBuilder();
-            var whereprops = GetAllProperties(whereConditions).ToArray();
-            sb.AppendFormat("Delete from {0}", name);
-            if (whereprops.Any())
-            {
-                sb.Append(" where ");
-                BuildWhere<T>(sb, whereprops);
-            }
-
-            if (Debugger.IsAttached)
-                Trace.WriteLine(String.Format("DeleteList<{0}> {1}", currenttype, sb));
-
-            return connection.ExecuteAsync(sb.ToString(), whereConditions, transaction, commandTimeout);
+            var sb = BuildDeleteListQuery<T>(whereConditions);
+            return connection.ExecuteAsync(sb, whereConditions, transaction, commandTimeout);
         }
 
         /// <summary>
@@ -480,22 +250,8 @@ namespace Dapper
         /// <returns>The number of records affected</returns>
         public static Task<int> DeleteListAsync<T>(this IDbConnection connection, string conditions, object parameters = null, IDbTransaction transaction = null, int? commandTimeout = null)
         {
-            if (string.IsNullOrEmpty(conditions))
-                throw new ArgumentException("DeleteList<T> requires a where clause");
-            if (!conditions.ToLower().Contains("where"))
-                throw new ArgumentException("DeleteList<T> requires a where clause and must contain the WHERE keyword");
-
-            var currenttype = typeof(T);
-            var name = GetTableName(currenttype);
-
-            var sb = new StringBuilder();
-            sb.AppendFormat("Delete from {0}", name);
-            sb.Append(" " + conditions);
-
-            if (Debugger.IsAttached)
-                Trace.WriteLine(String.Format("DeleteList<{0}> {1}", currenttype, sb));
-
-            return connection.ExecuteAsync(sb.ToString(), parameters, transaction, commandTimeout);
+            var sb = BuildDeleteListQuery<T>(conditions);
+            return connection.ExecuteAsync(sb, parameters, transaction, commandTimeout);
         }
 
         /// <summary>
@@ -514,17 +270,8 @@ namespace Dapper
         /// <returns>Returns a count of records.</returns>
         public static Task<int> RecordCountAsync<T>(this IDbConnection connection, string conditions = "", object parameters = null, IDbTransaction transaction = null, int? commandTimeout = null)
         {
-            var currenttype = typeof(T);
-            var name = GetTableName(currenttype);
-            var sb = new StringBuilder();
-            sb.Append("Select count(1)");
-            sb.AppendFormat(" from {0}", name);
-            sb.Append(" " + conditions);
-
-            if (Debugger.IsAttached)
-                Trace.WriteLine(String.Format("RecordCount<{0}>: {1}", currenttype, sb));
-
-            return connection.ExecuteScalarAsync<int>(sb.ToString(), parameters, transaction, commandTimeout);
+            var sb = BuildRecordCountQuery<T>(conditions);
+            return connection.ExecuteScalarAsync<int>(sb, parameters, transaction, commandTimeout);
         }
 
         /// <summary>
@@ -542,22 +289,7 @@ namespace Dapper
         /// <returns>Returns a count of records.</returns>
         public static Task<int> RecordCountAsync<T>(this IDbConnection connection, object whereConditions, IDbTransaction transaction = null, int? commandTimeout = null)
         {
-            var currenttype = typeof(T);
-            var name = GetTableName(currenttype);
-
-            var sb = new StringBuilder();
-            var whereprops = GetAllProperties(whereConditions).ToArray();
-            sb.Append("Select count(1)");
-            sb.AppendFormat(" from {0}", name);
-            if (whereprops.Any())
-            {
-                sb.Append(" where ");
-                BuildWhere<T>(sb, whereprops);
-            }
-
-            if (Debugger.IsAttached)
-                Trace.WriteLine(String.Format("RecordCount<{0}>: {1}", currenttype, sb));
-
+            var sb = BuildRecordCountQuery<T>(whereConditions);
             return connection.ExecuteScalarAsync<int>(sb.ToString(), whereConditions, transaction, commandTimeout);
         }
     }

--- a/Dapper.SimpleCRUDTests/Program.cs
+++ b/Dapper.SimpleCRUDTests/Program.cs
@@ -16,8 +16,8 @@ namespace Dapper.SimpleCRUDTests
             Setup();
             RunTests();
 
-            SetupSqLite();
-            RunTestsSqLite();
+            //SetupSqLite();
+            //RunTestsSqLite();
 
             //PostgreSQL tests assume port 5432 with username postgres and password postgrespass
             //they are commented out by default since postgres setup is required to run tests
@@ -32,7 +32,7 @@ namespace Dapper.SimpleCRUDTests
 
         private static void Setup()
         {
-            using (var connection = new SqlConnection(@"Data Source=.\sqlexpress;Initial Catalog=Master;Integrated Security=True"))
+            using (var connection = new SqlConnection(@"Data Source=localhost;Initial Catalog=Master;Integrated Security=True"))
             {
                 connection.Open();
                 try
@@ -45,7 +45,7 @@ namespace Dapper.SimpleCRUDTests
                 connection.Execute(@" CREATE DATABASE DapperSimpleCrudTestDb; ");
             }
 
-            using (var connection = new SqlConnection(@"Data Source = .\sqlexpress;Initial Catalog=DapperSimpleCrudTestDb;Integrated Security=True"))
+            using (var connection = new SqlConnection(@"Data Source = localhost;Initial Catalog=DapperSimpleCrudTestDb;Integrated Security=True"))
             {
                 connection.Open();
                 connection.Execute(@" create table Users (Id int IDENTITY(1,1) not null, Name nvarchar(100) not null, Age int not null, ScheduledDayOff int null, CreatedDate datetime DEFAULT(getdate())) ");
@@ -164,7 +164,7 @@ namespace Dapper.SimpleCRUDTests
             // Write result
             Console.WriteLine("Time elapsed: {0}", stopwatch.Elapsed);
 
-            using (var connection = new SqlConnection(@"Data Source=.\sqlexpress;Initial Catalog=Master;Integrated Security=True"))
+            using (var connection = new SqlConnection(@"Data Source=localhost;Initial Catalog=Master;Integrated Security=True"))
             {
                 connection.Open();
                 try

--- a/Dapper.SimpleCRUDTests/Tests.cs
+++ b/Dapper.SimpleCRUDTests/Tests.cs
@@ -192,7 +192,7 @@ namespace Dapper.SimpleCRUDTests
             }
             else
             {
-                connection = new SqlConnection(@"Data Source = .\sqlexpress;Initial Catalog=DapperSimpleCrudTestDb;Integrated Security=True;MultipleActiveResultSets=true;");
+                connection = new SqlConnection(@"Data Source = localhost;Initial Catalog=DapperSimpleCrudTestDb;Integrated Security=True;MultipleActiveResultSets=true;");
                 SimpleCRUD.SetDialect(SimpleCRUD.Dialect.SQLServer);
             }
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+This is my fork of Dapper.SimpleCRUD.
+
+I have refactored the code slighty to help with maintainablity - and I have added SoftDelete feature.
+
+Huge credit to ericdc1 for making such a useful mini dapper helper!
+
+
 Dapper.SimpleCRUD - simple CRUD helpers for Dapper
 ========================================
 Features


### PR DESCRIPTION
This is a fork I made - not sure if it's something you are interested in. If you are let me know and I'll finalise it up properly.

You can mark an entity as a soft deletable entity by either
- Having a property called Deleted as DateTimeOffset
- Having a property that is DateTimeOffset marked with the DeletedAttribute

I have added unit tests to test delete, as well making sure existing calls are not broken.

All getters now include an optional param to included deleted records, and delete includes an optional parameter to Delete records permanently.

I also refactored the code slightly to improve the code re-use. I hope you don't mind but it made it easier to add the deleted feature.

If you would like this feature then I will need to run all unit tests on all DB types as so far I have only tested on MSSQL

Thanks for such a great repo - saved us loads of time on our CRUD operations!
