### PR TITLE
Allowing Interface variable reference to be used for Update & Insert

### DIFF
--- a/Dapper.SimpleCRUD/SimpleCRUD.cs
+++ b/Dapper.SimpleCRUD/SimpleCRUD.cs
@@ -352,6 +352,13 @@ namespace Dapper
         /// <returns>The ID (primary key) of the newly inserted record if it is identity using the defined type, otherwise null</returns>
         public static TKey Insert<TKey, TEntity>(this IDbConnection connection, TEntity entityToInsert, IDbTransaction transaction = null, int? commandTimeout = null)
         {
+            if (typeof(TEntity).IsInterface) //FallBack to BaseType Generic Method : https://stackoverflow.com/questions/4101784/calling-a-generic-method-with-a-dynamic-type
+            {
+                return (TKey)typeof(SimpleCRUD)
+                    .GetMethods().Where(methodInfo=>methodInfo.Name == nameof(Insert) && methodInfo.GetGenericArguments().Count()==2).Single()
+                    .MakeGenericMethod(new Type[] { typeof(TKey), entityToInsert.GetType() })
+                    .Invoke(null, new object[] { connection,entityToInsert,transaction,commandTimeout });
+            }
             var idProps = GetIdProperties(entityToInsert).ToList();
 
             if (!idProps.Any())
@@ -429,6 +436,13 @@ namespace Dapper
         /// <returns>The number of affected records</returns>
         public static int Update<TEntity>(this IDbConnection connection, TEntity entityToUpdate, IDbTransaction transaction = null, int? commandTimeout = null)
         {
+            if (typeof(TEntity).IsInterface) //FallBack to BaseType Generic Method: https://stackoverflow.com/questions/4101784/calling-a-generic-method-with-a-dynamic-type
+            {
+                return (int)typeof(SimpleCRUD)
+                    .GetMethods().Where(methodInfo => methodInfo.Name == nameof(Update) && methodInfo.GetGenericArguments().Count() == 1).Single()
+                    .MakeGenericMethod(new Type[] { entityToUpdate.GetType() })
+                    .Invoke(null, new object[] { connection, entityToUpdate, transaction, commandTimeout });
+            }
             var masterSb = new StringBuilder();
             StringBuilderCache(masterSb, $"{typeof(TEntity).FullName}_Update", sb =>
             {

--- a/Dapper.SimpleCRUD/SimpleCRUDAsync.cs
+++ b/Dapper.SimpleCRUD/SimpleCRUDAsync.cs
@@ -331,9 +331,9 @@ namespace Dapper
             if (typeof(TEntity).IsInterface) //FallBack to BaseType Generic Method : https://stackoverflow.com/questions/4101784/calling-a-generic-method-with-a-dynamic-type
             {
                 return await(Task<int>)typeof(SimpleCRUD)
-                   .GetMethods().Where(methodInfo => methodInfo.Name == nameof(UpdateAsync) && methodInfo.GetGenericArguments().Count() == 2).Single()
+                   .GetMethods().Where(methodInfo => methodInfo.Name == nameof(UpdateAsync) && methodInfo.GetGenericArguments().Count() == 1).Single()
                    .MakeGenericMethod(new Type[] { entityToUpdate.GetType() })
-                   .Invoke(null, new object[] { connection, entityToUpdate, transaction, commandTimeout });
+                   .Invoke(null, new object[] { connection, entityToUpdate, transaction, commandTimeout, token });
             }
             var idProps = GetIdProperties(entityToUpdate).ToList();
 

--- a/Dapper.SimpleCRUDTests/Program.cs
+++ b/Dapper.SimpleCRUDTests/Program.cs
@@ -11,6 +11,8 @@ namespace Dapper.SimpleCRUDTests
 {
     class Program
     {
+        public const string SQLServerName = @".\sqlexpress";
+
         static void Main()
         {
             Setup();
@@ -32,7 +34,7 @@ namespace Dapper.SimpleCRUDTests
 
         private static void Setup()
         {
-            using (var connection = new SqlConnection(@"Data Source=.\sqlexpress;Initial Catalog=Master;Integrated Security=True"))
+            using (var connection = new SqlConnection($@"Data Source={SQLServerName};Initial Catalog=Master;Integrated Security=True"))
             {
                 connection.Open();
                 try
@@ -45,7 +47,7 @@ namespace Dapper.SimpleCRUDTests
                 connection.Execute(@" CREATE DATABASE DapperSimpleCrudTestDb; ");
             }
 
-            using (var connection = new SqlConnection(@"Data Source = .\sqlexpress;Initial Catalog=DapperSimpleCrudTestDb;Integrated Security=True"))
+            using (var connection = new SqlConnection($@"Data Source ={SQLServerName};Initial Catalog=DapperSimpleCrudTestDb;Integrated Security=True"))
             {
                 connection.Open();
                 connection.Execute(@" create table Users (Id int IDENTITY(1,1) not null, Name nvarchar(100) not null, Age int not null, ScheduledDayOff int null, CreatedDate datetime DEFAULT(getdate())) ");
@@ -164,7 +166,7 @@ namespace Dapper.SimpleCRUDTests
             // Write result
             Console.WriteLine("Time elapsed: {0}", stopwatch.Elapsed);
 
-            using (var connection = new SqlConnection(@"Data Source=.\sqlexpress;Initial Catalog=Master;Integrated Security=True"))
+            using (var connection = new SqlConnection($@"Data Source={SQLServerName};Initial Catalog=Master;Integrated Security=True"))
             {
                 connection.Open();
                 try

--- a/Dapper.SimpleCRUDTests/Tests.cs
+++ b/Dapper.SimpleCRUDTests/Tests.cs
@@ -101,6 +101,23 @@ namespace Dapper.SimpleCRUDTests
         public int Population { get; set; }
     }
 
+    public interface INameColumn
+    {
+        string Name { get; set; }
+    }
+
+    [Table("City")]
+    public class CityWithIName : City, INameColumn
+    {
+
+    }
+
+    [Table("Users")]
+    public class UserWithIName : User, INameColumn
+    {
+
+    }
+
     public class GUIDTest
     {
         [Key]
@@ -192,7 +209,7 @@ namespace Dapper.SimpleCRUDTests
             }
             else
             {
-                connection = new SqlConnection(@"Data Source = .\sqlexpress;Initial Catalog=DapperSimpleCrudTestDb;Integrated Security=True;MultipleActiveResultSets=true;");
+                connection = new SqlConnection($@"Data Source={Program.SQLServerName};Initial Catalog=DapperSimpleCrudTestDb;Integrated Security=True;MultipleActiveResultSets=true;");
                 SimpleCRUD.SetDialect(SimpleCRUD.Dialect.SQLServer);
             }
 
@@ -214,7 +231,7 @@ namespace Dapper.SimpleCRUDTests
             }
         }
 
-        public void TestMassInsert() 
+        public void TestMassInsert()
         {
             //With cached strinb builder, this tests runs 2.5X faster (From 400ms to 180ms)
             using (var connection = GetOpenConnection())
@@ -1289,6 +1306,93 @@ namespace Dapper.SimpleCRUDTests
                 list.Count().IsEqualTo(1);
 
                 connection.Execute("Delete from Users");
+            }
+        }
+
+        public void TestInsertUsingInterface()
+        {
+            using (var connection = GetOpenConnection())
+            using (var transaction = connection.BeginTransaction())
+            {
+                INameColumn newUser = new UserWithIName
+                {
+                    Age = 40,
+                    Name = "Jonathan Larouche",
+                    ScheduledDayOff = DayOfWeek.Sunday,
+                    CreatedDate = new DateTime(2000, 1, 1)
+                };
+
+                connection.Insert(newUser, transaction);
+
+                INameColumn newCity = new CityWithIName
+                {
+                    Name = "Montreal",
+                    Population = 5675
+                };
+
+                connection.Insert<string, INameColumn>(newCity, transaction);
+
+                var user = connection.GetList<UserWithIName>(new { Name = "Jonathan Larouche" }, transaction).FirstOrDefault();
+                user.Age.IsEqualTo(40);
+                var city = connection.GetList<CityWithIName>(new { Name = "Montreal" }, transaction).FirstOrDefault();
+                city.Population.IsEqualTo(5675);
+
+            }
+        }
+
+        public async void TestInsertAsyncUsingInterface()
+        {
+            using (var connection = GetOpenConnection())
+            using (var transaction = connection.BeginTransaction())
+            {
+                INameColumn newUser = new UserWithIName
+                {
+                    Age = 40,
+                    Name = "Jonathan Larouche",
+                    ScheduledDayOff = DayOfWeek.Sunday,
+                    CreatedDate = new DateTime(2000, 1, 1)
+                };
+
+                await connection.InsertAsync(newUser, transaction);
+                
+                var user = connection.GetList<UserWithIName>(new { Name = "Jonathan Larouche" }, transaction).FirstOrDefault();
+                user.Age.IsEqualTo(40);
+
+            }
+        }
+
+        public void TestUpdateUsingInterface()
+        {
+            using (var connection = GetOpenConnection())
+            using (var transaction = connection.BeginTransaction())
+            {
+                INameColumn newUser = new UserWithIName
+                {
+                    Age = 40,
+                    Name = "Jonathan Larouche",
+                    ScheduledDayOff = DayOfWeek.Sunday,
+                    CreatedDate = new DateTime(2000, 1, 1)
+                };
+
+                ((UserWithIName)newUser).Id = connection.Insert(newUser, transaction).Value;
+                ((UserWithIName)newUser).Age = 41;
+                connection.Update(newUser, transaction);
+
+                INameColumn newCity = new CityWithIName
+                {
+                    Name = "Montreal",
+                    Population = 5675
+                };
+
+                connection.Insert<string, INameColumn>(newCity, transaction);
+                ((CityWithIName)newCity).Population = 6000;
+                connection.Update(newCity, transaction);
+
+                var user = connection.GetList<UserWithIName>(new { Name = "Jonathan Larouche" }, transaction).FirstOrDefault();
+                user.Age.IsEqualTo(41);
+                var city = connection.GetList<CityWithIName>(new { Name = "Montreal" }, transaction).FirstOrDefault();
+                city.Population.IsEqualTo(6000);
+
             }
         }
 


### PR DESCRIPTION
New Feature:
Allow to Pass Interface Type to Insert,InsertAsync,Update & UpdateAsync.
This could be useful when you have to Insert/Update records of many table using the same Interface, 
Eg: changing the name by using the IName interface.
Update<T> & Insert<T> will then use the instance base type to identify the good Query/Columns

Fixes
UpdateAsync signature is now fully async

Other (Unit Tests):
Added 4 Tests for Methods changes
Put SQL Instance Name in string constant to make it easier to change when local instance is not.\sqlexpress