### PR TITLE
Pointed nuspec at a Dapper version that exists.

### DIFF
--- a/Dapper.SimpleCRUD.nuspec
+++ b/Dapper.SimpleCRUD.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Dapper.SimpleCRUD</id>
-    <version>2.2.0.0</version>
+    <version>2.2.1.0</version>
     <title>Dapper.SimpleCRUD</title>
     <authors>Eric Coffman</authors>
     <owners>Eric Coffman</owners>
@@ -56,7 +56,7 @@
     <dependencies>	  
 	  <group targetFramework=".NETStandard2.0">
         <dependency id="Microsoft.CSharp" version="4.4.0" />
-		<dependency id="Dapper" version="2.0" />
+		<dependency id="Dapper" version="2.0.4" />
 	  </group>    
     </dependencies>
 	

--- a/History.txt
+++ b/History.txt
@@ -37,3 +37,4 @@
 * version 2.0.1 Re-add SQLite, allow string primary keys
 * version 2.1.0 Speed improvements (thanks jonathanlarouche)
 * version 2.2.0 Dapper 2.x support
+* version 2.2.1 Pointed to Dapper 2.0.4


### PR DESCRIPTION
Pointed nuspec at Dapper 2.0.4 because 2.0 does not exist and causes build warnings.