### PR TITLE
Added a paramPrefix variable to properly handle Oracle dialect

### DIFF
--- a/Dapper.SimpleCRUD/SimpleCRUDAsync.cs
+++ b/Dapper.SimpleCRUD/SimpleCRUDAsync.cs
@@ -46,16 +46,16 @@ namespace Dapper
             {
                 if (i > 0)
                     sb.Append(" and ");
-                sb.AppendFormat("{0} = @{1}", GetColumnName(idProps[i]), idProps[i].Name);
+                sb.AppendFormat("{0} = {2}{1}", GetColumnName(idProps[i]), idProps[i].Name, _paramPrefix);
             }
 
             var dynParms = new DynamicParameters();
             if (idProps.Count == 1)
-                dynParms.Add("@" + idProps.First().Name, id);
+                dynParms.Add(_paramPrefix + idProps.First().Name, id);
             else
             {
                 foreach (var prop in idProps)
-                    dynParms.Add("@" + prop.Name, id.GetType().GetProperty(prop.Name).GetValue(id, null));
+                    dynParms.Add(_paramPrefix + prop.Name, id.GetType().GetProperty(prop.Name).GetValue(id, null));
             }
 
             if (Debugger.IsAttached)
@@ -413,16 +413,16 @@ namespace Dapper
             {
                 if (i > 0)
                     sb.Append(" and ");
-                sb.AppendFormat("{0} = @{1}", GetColumnName(idProps[i]), idProps[i].Name);
+                sb.AppendFormat("{0} = {2}{1}", GetColumnName(idProps[i]), idProps[i].Name, _paramPrefix);
             }
 
             var dynParms = new DynamicParameters();
             if (idProps.Count == 1)
-                dynParms.Add("@" + idProps.First().Name, id);
+                dynParms.Add(_paramPrefix + idProps.First().Name, id);
             else
             {
                 foreach (var prop in idProps)
-                    dynParms.Add("@" + prop.Name, prop.GetValue(id));
+                    dynParms.Add(_paramPrefix + prop.Name, prop.GetValue(id));
             }
 
             if (Debugger.IsAttached)
@@ -567,4 +567,3 @@ namespace Dapper
         }
     }
 }
-


### PR DESCRIPTION
Added a new variable for dialects to handle the dynamic parameter prefix, changed to ":" for Oracle only